### PR TITLE
never wrap Markdown prose

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   tabWidth: 4,
   printWidth: 120,
-  proseWrap: 'preserve',
+  proseWrap: 'never',
   semi: false,
   trailingComma: 'es5',
   singleQuote: true,


### PR DESCRIPTION
This removes unnecessary line breaks from Markdown prose.

About half of our Markdown files had line breaks and half didn't. There certainly are arguments for either way, but it's good to be consistent.

FYI, this will cause big diffs the first time it is applied.

See https://prettier.io/docs/en/options.html#prose-wrap.